### PR TITLE
Add operations to modify and delete accounts.

### DIFF
--- a/src/models/assets.py
+++ b/src/models/assets.py
@@ -22,13 +22,23 @@ class AccountType(str, Enum):
         return None
 
 
-class AccountIn(BaseModel):
+class Account(BaseModel):
     type: AccountType
-    holder: str = None
     code: str
     description: str
 
 
-class Account(AccountIn):
+class AccountIn(Account):
+    holder: str = None
+
+
+class OwnedAccount(Account):
     owner: str
-    holder: Union[None, Institution]
+
+
+class CashAccount(OwnedAccount):
+    type = AccountType.cash
+
+
+class FinancialAccount(OwnedAccount):
+    holder: Institution

--- a/src/operations/assets.py
+++ b/src/operations/assets.py
@@ -9,33 +9,14 @@ from .auth import resolve_user
 
 def add_account(account: AccountIn, user: User = Depends(resolve_user)):
     try:
-        data = account.dict(exclude_none=True)
-        data['owner'] = user.username
-
-        if not account.type.holder_type:
-            data.pop('holder', None)
-
-        else:
-            if not data.get('holder'):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f'Account holder is required for {account.type} account.'
-                )
-
-            holder_data = database.institutions.find_one(
-                {
-                    'type': account.type.holder_type,
-                    'code': data['holder']
-                }
-            )
-            if not holder_data:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f'Institution of type {account.type.holder_type} with code {account.holder} does not exist.'
-                )
-            data['holder'] = holder_data
-
+        data = _resolve_account_data(account, user)
         database.accounts.insert_one(data)
+
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'{ve}'
+        )
 
     except DuplicateKeyError:
         raise HTTPException(
@@ -48,3 +29,47 @@ def add_account(account: AccountIn, user: User = Depends(resolve_user)):
 
 def get_accounts(user: User = Depends(resolve_user)):
     return [a for a in database.accounts.find({'owner': user.username})]
+
+
+def modify_account(code: str, account: AccountIn, user: User = Depends(resolve_user)):
+    try:
+        data = _resolve_account_data(account, user)
+        database.accounts.update_one({'owner': user.username, 'code': code}, {'$set': data})
+
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'{ve}'
+        )
+
+    return data
+
+
+def delete_account(code: str, user: User = Depends(resolve_user)):
+    database.accounts.delete_one({'owner': user.username, 'code': code})
+
+
+def _resolve_account_data(account, user):
+    data = account.dict(exclude_none=True)
+    data['owner'] = user.username
+
+    if not account.type.holder_type:
+        data.pop('holder', None)
+
+    else:
+        if not data.get('holder'):
+            raise ValueError(f'Account holder is required for {account.type} account.')
+
+        holder_data = database.institutions.find_one(
+            {
+                'type': account.type.holder_type,
+                'code': data['holder']
+            }
+        )
+        if not holder_data:
+            raise ValueError(f'Institution of type {account.type.holder_type} with code '
+                             f'{account.holder} does not exist.')
+        data['holder'] = holder_data
+
+    return data
+

--- a/src/operations/core.py
+++ b/src/operations/core.py
@@ -44,6 +44,12 @@ def add_instrument(instrument: InstrumentIn, _: User = Depends(validate_admin_us
         data = instrument.dict(exclude_none=True)
         database.instruments.insert_one(data)
 
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'{ve}'
+        )
+
     except DuplicateKeyError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -59,13 +65,20 @@ def get_instruments(_: User = Depends(resolve_user)):
 
 
 def modify_instrument(code: str, instrument: InstrumentIn, _: User = Depends(validate_admin_user)):
-    if instrument.type == InstrumentType.security:
-        exchange_code, symbol = code.split(':')
-        _set_instrument_exchange(instrument)
+    try:
+        if instrument.type == InstrumentType.security:
+            exchange_code, symbol = code.split(':')
+            _set_instrument_exchange(instrument)
 
-    else:
-        exchange_code = None
-        symbol = code
+        else:
+            exchange_code = None
+            symbol = code
+
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'{ve}'
+        )
 
     data = instrument.dict(exclude_none=True)
     database.instruments.update_one(
@@ -77,10 +90,7 @@ def modify_instrument(code: str, instrument: InstrumentIn, _: User = Depends(val
 
 def _set_instrument_exchange(instrument):
     if not instrument.exchange:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f'Instrument of type security must have an exchange.'
-        )
+        raise ValueError('Instrument of type security must have an exchange.')
 
     instrument.exchange = database.institutions.find_one(
         {

--- a/src/service.py
+++ b/src/service.py
@@ -5,11 +5,11 @@ from pydantic.fields import List, Union
 from .config import database
 from .models.auth import User
 from .models.core import Institution, Instrument, Security
-from .models.assets import Account
+from .models.assets import FinancialAccount, CashAccount
 from .operations.auth import add_user, authenticate, get_current_user
 from .operations.core import add_institution, get_institutions, modify_institution, delete_institution, \
     add_instrument, get_instruments, modify_instrument, delete_instrument
-from .operations.assets import add_account, get_accounts
+from .operations.assets import add_account, get_accounts, modify_account, delete_account
 
 
 # Service
@@ -68,5 +68,7 @@ service.get('/instruments', response_model=List[Union[Security, Instrument]])(ge
 service.put('/instruments/{code}', response_model=Union[Security, Instrument])(modify_instrument)
 service.delete('/instruments/{code}')(delete_instrument)
 
-service.post('/accounts', response_model=Account)(add_account)
-service.get('/accounts', response_model=List[Account])(get_accounts)
+service.post('/accounts', response_model=Union[FinancialAccount, CashAccount])(add_account)
+service.get('/accounts', response_model=List[Union[FinancialAccount, CashAccount]])(get_accounts)
+service.put('/accounts/{code}', response_model=Union[FinancialAccount, CashAccount])(modify_account)
+service.delete('/accounts/{code}')(delete_account)

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.models.auth import UserIn
 from src.models.core import Institution, InstitutionType, Instrument, InstrumentIn, InstrumentType, Security
-from src.models.assets import Account, AccountIn, AccountType
+from src.models.assets import AccountIn, AccountType, CashAccount, FinancialAccount
 
 
 # Users
@@ -129,7 +129,7 @@ def account_cash(account_cash_input, normal_user_input):
     data = copy.copy(account_cash_input)
     data['owner'] = normal_user_input['username']
     data['holder'] = None
-    return Account(**data)
+    return CashAccount(**data)
 
 @pytest.fixture
 def account_bank_input():
@@ -149,7 +149,7 @@ def account_bank(account_bank_input, normal_user_input, bank_input):
     data = copy.copy(account_bank_input)
     data['owner'] = normal_user_input['username']
     data['holder'] = bank_input
-    return Account(**data)
+    return FinancialAccount(**data)
 
 @pytest.fixture
 def account_broker_input():
@@ -169,4 +169,4 @@ def account_broker(account_broker_input, normal_user_input, broker_input):
     data = copy.copy(account_broker_input)
     data['owner'] = normal_user_input['username']
     data['holder'] = broker_input
-    return Account(**data)
+    return FinancialAccount(**data)

--- a/test/test_operations_auth.py
+++ b/test/test_operations_auth.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException
 from jwt import PyJWTError
 from pymongo.errors import DuplicateKeyError
 
-from src.operations.auth import add_user, authenticate, resolve_user, validate_admin_user
+from src.operations.auth import add_user, authenticate, resolve_user, validate_admin_user, get_current_user
 from .fixtures import normal_user_in, normal_user_input, admin_user_input, admin_user_in
 
 

--- a/test/test_operations_core.py
+++ b/test/test_operations_core.py
@@ -127,6 +127,19 @@ def test_modify_currency_success(collection_mock, institutions_mock, currency_in
 
 @patch('src.operations.core.database.institutions')
 @patch('src.operations.core.database.instruments')
+def test_modify_security_failure(collection_mock, institutions_mock, security_in):
+    security_in.exchange = None
+
+    with pytest.raises(HTTPException):
+        modify_instrument(security_in.code, security_in)
+
+    # No DB ops done due to validation error
+    assert not collection_mock.insert_one.called
+    assert not institutions_mock.find_one.called
+
+
+@patch('src.operations.core.database.institutions')
+@patch('src.operations.core.database.instruments')
 def test_modify_security_success(collection_mock, institutions_mock, security_in, security):
     institutions_mock.find_one.return_value = security.exchange.dict(exclude_none=True)
     security_in.description = 'Amazon Inc'


### PR DESCRIPTION
Resolve #34: add operation `modify_account`.
Resolve #35: add operation `delete_account`.
Also split account models into `CashAccount` and
`FinancialAccount`, moved some validation logic and improved
unit test coverage.